### PR TITLE
Add Antigravity CLI Tips to Tutorials & Articles

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Tips for getting the most out of the built-in AI Agent.
 ## 📝 Tutorials & Articles
 *   [Getting Started with Antigravity](https://medium.com/google-developers) - Official kickstart guide.
 *   [Migrating from VS Code](https://dev.to) - Keybinding mapping and workspace setup.
+*   [Antigravity CLI Tips](https://github.com/ykdojo/antigravity-cli-tips) - Practical tips for getting the most out of the Antigravity CLI (`agy`).
 
 ---
 


### PR DESCRIPTION
Adds [Antigravity CLI Tips](https://github.com/ykdojo/antigravity-cli-tips), a collection of practical tips for the Antigravity CLI (`agy`), to the Tutorials & Articles section.