### PR TITLE
Add WFD Faro (companion app for Antigravity swarm monitoring)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The best place to get help, share prompts, and discuss plugin development is our
 *Currently populating... [Submit a PR to add yours!]*
 
 *   **[Community Plugin Template](https://github.com/placeholder)** - A starter repo for building your own Antigravity extensions.
+*   **[WFD Faro](https://btcwfd.github.io/wfd-faro-site/)** - Companion desktop app (Windows) that surfaces the live health of your Antigravity subagent swarm — active agents, alerts, orchestrator status — right next to the rest of your projects, so you can watch your agents without keeping the monitor window open.
 
 ## 🤖 Agent Workflows & Prompts
 Tips for getting the most out of the built-in AI Agent.


### PR DESCRIPTION
Adds **WFD Faro** to Extensions & Plugins.

WFD Faro is a Windows desktop panel that helps developers keep track of many projects at once (git health, kanban, scripts, dependency audits). Relevant to this list: it connects to the **Antigravity subagent monitor** and shows the live health of your agent swarm — active agents, alerts, orchestrator status — alongside the rest of your projects, so you can watch your agents without keeping a separate monitor window open.

- Site & download (Windows 10/11, free to start): https://btcwfd.github.io/wfd-faro-site/

I described it as a *companion app* rather than an in-IDE plugin so it's not miscategorized — happy to move it to a different section if you'd prefer a "Tools" / "Companion Apps" heading. Thanks for curating this list!